### PR TITLE
Add code-insiders symlinks

### DIFF
--- a/Moka/16x16/apps/code-insiders.png
+++ b/Moka/16x16/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/16x16@2x/apps/code-insiders.png
+++ b/Moka/16x16@2x/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/22x22/apps/code-insiders.png
+++ b/Moka/22x22/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/22x22@2x/apps/code-insiders.png
+++ b/Moka/22x22@2x/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/24x24/apps/code-insiders.png
+++ b/Moka/24x24/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/24x24@2x/apps/code-insiders.png
+++ b/Moka/24x24@2x/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/256x256/apps/code-insiders.png
+++ b/Moka/256x256/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/256x256@2x/apps/code-insiders.png
+++ b/Moka/256x256@2x/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/32x32/apps/code-insiders.png
+++ b/Moka/32x32/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/32x32@2x/apps/code-insiders.png
+++ b/Moka/32x32@2x/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/48x48/apps/code-insiders.png
+++ b/Moka/48x48/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/48x48@2x/apps/code-insiders.png
+++ b/Moka/48x48@2x/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/64x64/apps/code-insiders.png
+++ b/Moka/64x64/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/64x64@2x/apps/code-insiders.png
+++ b/Moka/64x64@2x/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/96x96/apps/code-insiders.png
+++ b/Moka/96x96/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png

--- a/Moka/96x96@2x/apps/code-insiders.png
+++ b/Moka/96x96@2x/apps/code-insiders.png
@@ -1,0 +1,1 @@
+visual-studio-code-insiders.png


### PR DESCRIPTION
Now that #316 is merged, I noticed that the official RPMs use `code-insiders.png` for their icon's name. These symlinks add support for this icon name