### PR TITLE
Add openshot-qt symlinks

### DIFF
--- a/Moka/16x16/apps/openshot-qt.png
+++ b/Moka/16x16/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/16x16@2x/apps/openshot-qt.png
+++ b/Moka/16x16@2x/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/22x22/apps/openshot-qt.png
+++ b/Moka/22x22/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/22x22@2x/apps/openshot-qt.png
+++ b/Moka/22x22@2x/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/24x24/apps/openshot-qt.png
+++ b/Moka/24x24/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/24x24@2x/apps/openshot-qt.png
+++ b/Moka/24x24@2x/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/256x256/apps/openshot-qt.png
+++ b/Moka/256x256/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/256x256@2x/apps/openshot-qt.png
+++ b/Moka/256x256@2x/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/32x32/apps/openshot-qt.png
+++ b/Moka/32x32/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/32x32@2x/apps/openshot-qt.png
+++ b/Moka/32x32@2x/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/48x48/apps/openshot-qt.png
+++ b/Moka/48x48/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/48x48@2x/apps/openshot-qt.png
+++ b/Moka/48x48@2x/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/64x64/apps/openshot-qt.png
+++ b/Moka/64x64/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/64x64@2x/apps/openshot-qt.png
+++ b/Moka/64x64@2x/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/96x96/apps/openshot-qt.png
+++ b/Moka/96x96/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png

--- a/Moka/96x96@2x/apps/openshot-qt.png
+++ b/Moka/96x96@2x/apps/openshot-qt.png
@@ -1,0 +1,1 @@
+openshot.png


### PR DESCRIPTION
In some cases the openshot icon is named `openshot-qt` instead of `openshot`, at least in the Archlinux package and in the RPMfusion package for Fedora