### PR TITLE
Add ghetto-skype symlinks

### DIFF
--- a/Moka/16x16/apps/ghetto-skype.png
+++ b/Moka/16x16/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/16x16@2x/apps/ghetto-skype.png
+++ b/Moka/16x16@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/22x22/apps/ghetto-skype.png
+++ b/Moka/22x22/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/22x22@2x/apps/ghetto-skype.png
+++ b/Moka/22x22@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/24x24/apps/ghetto-skype.png
+++ b/Moka/24x24/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/24x24@2x/apps/ghetto-skype.png
+++ b/Moka/24x24@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/256x256/apps/ghetto-skype.png
+++ b/Moka/256x256/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/256x256@2x/apps/ghetto-skype.png
+++ b/Moka/256x256@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/32x32/apps/ghetto-skype.png
+++ b/Moka/32x32/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/32x32@2x/apps/ghetto-skype.png
+++ b/Moka/32x32@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/48x48/apps/ghetto-skype.png
+++ b/Moka/48x48/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/48x48@2x/apps/ghetto-skype.png
+++ b/Moka/48x48@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/64x64/apps/ghetto-skype.png
+++ b/Moka/64x64/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/64x64@2x/apps/ghetto-skype.png
+++ b/Moka/64x64@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/96x96/apps/ghetto-skype.png
+++ b/Moka/96x96/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Moka/96x96@2x/apps/ghetto-skype.png
+++ b/Moka/96x96@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png


### PR DESCRIPTION
I don't know if it's a good idea, but Ghetto Skype is basically a Skype client and it uses the same icon as the official Skype application.