### PR TITLE
Add regedit and wine-regedit symlinks

### DIFF
--- a/Moka/16x16/apps/regedit.png
+++ b/Moka/16x16/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/16x16/apps/wine-regedit.png
+++ b/Moka/16x16/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/16x16@2x/apps/regedit.png
+++ b/Moka/16x16@2x/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/16x16@2x/apps/wine-regedit.png
+++ b/Moka/16x16@2x/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/22x22/apps/regedit.png
+++ b/Moka/22x22/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/22x22/apps/wine-regedit.png
+++ b/Moka/22x22/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/22x22@2x/apps/regedit.png
+++ b/Moka/22x22@2x/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/22x22@2x/apps/wine-regedit.png
+++ b/Moka/22x22@2x/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/24x24/apps/regedit.png
+++ b/Moka/24x24/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/24x24/apps/wine-regedit.png
+++ b/Moka/24x24/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/24x24@2x/apps/regedit.png
+++ b/Moka/24x24@2x/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/24x24@2x/apps/wine-regedit.png
+++ b/Moka/24x24@2x/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/256x256/apps/regedit.png
+++ b/Moka/256x256/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/256x256/apps/wine-regedit.png
+++ b/Moka/256x256/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/256x256@2x/apps/regedit.png
+++ b/Moka/256x256@2x/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/256x256@2x/apps/wine-regedit.png
+++ b/Moka/256x256@2x/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/32x32/apps/regedit.png
+++ b/Moka/32x32/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/32x32/apps/wine-regedit.png
+++ b/Moka/32x32/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/32x32@2x/apps/regedit.png
+++ b/Moka/32x32@2x/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/32x32@2x/apps/wine-regedit.png
+++ b/Moka/32x32@2x/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/48x48/apps/regedit.png
+++ b/Moka/48x48/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/48x48/apps/wine-regedit.png
+++ b/Moka/48x48/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/48x48@2x/apps/regedit.png
+++ b/Moka/48x48@2x/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/48x48@2x/apps/wine-regedit.png
+++ b/Moka/48x48@2x/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/64x64/apps/regedit.png
+++ b/Moka/64x64/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/64x64/apps/wine-regedit.png
+++ b/Moka/64x64/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/64x64@2x/apps/regedit.png
+++ b/Moka/64x64@2x/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/64x64@2x/apps/wine-regedit.png
+++ b/Moka/64x64@2x/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/96x96/apps/regedit.png
+++ b/Moka/96x96/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/96x96/apps/wine-regedit.png
+++ b/Moka/96x96/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/96x96@2x/apps/regedit.png
+++ b/Moka/96x96@2x/apps/regedit.png
@@ -1,0 +1,1 @@
+wine.png

--- a/Moka/96x96@2x/apps/wine-regedit.png
+++ b/Moka/96x96@2x/apps/wine-regedit.png
@@ -1,0 +1,1 @@
+wine.png


### PR DESCRIPTION
Wine has a regedit app and an associated icon, but right now there is no Moka icon for it. Would it be acceptable to use the default wine icon until a better one is available ?