### PR TITLE
Support for io.github.GnomeMpv

### DIFF
--- a/Moka/16x16/apps/io.github.GnomeMpv.png
+++ b/Moka/16x16/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/16x16@2x/apps/io.github.GnomeMpv.png
+++ b/Moka/16x16@2x/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/22x22/apps/io.github.GnomeMpv.png
+++ b/Moka/22x22/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/22x22@2x/apps/io.github.GnomeMpv.png
+++ b/Moka/22x22@2x/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/24x24/apps/io.github.GnomeMpv.png
+++ b/Moka/24x24/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/24x24@2x/apps/io.github.GnomeMpv.png
+++ b/Moka/24x24@2x/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/256x256/apps/io.github.GnomeMpv.png
+++ b/Moka/256x256/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/256x256@2x/apps/io.github.GnomeMpv.png
+++ b/Moka/256x256@2x/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/32x32/apps/io.github.GnomeMpv.png
+++ b/Moka/32x32/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/32x32@2x/apps/io.github.GnomeMpv.png
+++ b/Moka/32x32@2x/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/48x48/apps/io.github.GnomeMpv.png
+++ b/Moka/48x48/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/48x48@2x/apps/io.github.GnomeMpv.png
+++ b/Moka/48x48@2x/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/64x64/apps/io.github.GnomeMpv.png
+++ b/Moka/64x64/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/64x64@2x/apps/io.github.GnomeMpv.png
+++ b/Moka/64x64@2x/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/96x96/apps/io.github.GnomeMpv.png
+++ b/Moka/96x96/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/96x96@2x/apps/io.github.GnomeMpv.png
+++ b/Moka/96x96@2x/apps/io.github.GnomeMpv.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/src/symlinks/bitmaps/apps.list
+++ b/src/symlinks/bitmaps/apps.list
@@ -268,6 +268,7 @@ gnome-games.png org.gnome.Games.png
 gnome-klotski.png gnotski.png
 gnome-mahjongg.png org.gnome.Mahjongg.png
 gnome-maps.png org.gnome.Maps.png
+gnome-mpv.png io.github.GnomeMpv.png
 gnome-music.png org.gnome.Music.png
 gnome-nettool.png nmap_icon.png
 gnome-nettool.png zenmap.png


### PR DESCRIPTION
Added symbolic links for io.github.GnomeMpv, which is used in Solus Budgie (perhaps elsewhere as well). Also updated app.list to support generation of symbolic links. 